### PR TITLE
Verify signatures

### DIFF
--- a/.idea/dictionaries/david.xml
+++ b/.idea/dictionaries/david.xml
@@ -1,14 +1,20 @@
 <component name="ProjectDictionaryState">
   <dictionary name="david">
     <words>
+      <w>aolp</w>
       <w>aqqe</w>
+      <w>avpf</w>
       <w>awgg</w>
       <w>bama</w>
       <w>bamasdbg</w>
+      <w>baqefaaocaq</w>
       <w>baqufad</w>
       <w>bcjw</w>
+      <w>bezr</w>
       <w>bgkqhki</w>
+      <w>bkgrr</w>
       <w>bqxi</w>
+      <w>cacz</w>
       <w>caqyi</w>
       <w>certspotter</w>
       <w>cftppk</w>
@@ -18,39 +24,55 @@
       <w>cphg</w>
       <w>cpoln</w>
       <w>cqydvqqg</w>
+      <w>ctlog</w>
       <w>ctor</w>
       <w>ctserver</w>
       <w>culrj</w>
+      <w>cwqskwb</w>
       <w>dcuk</w>
       <w>difjpt</w>
+      <w>dpco</w>
       <w>dqebaquaa</w>
       <w>dzua</w>
       <w>ebtadaqh</w>
+      <w>ecdsa</w>
       <w>edgecombe</w>
       <w>eeef</w>
       <w>efah</w>
       <w>efyoz</w>
       <w>etap</w>
+      <w>euzzr</w>
       <w>fkgj</w>
       <w>foar</w>
       <w>ggod</w>
       <w>gjcz</w>
+      <w>glrrgmg</w>
       <w>gnks</w>
       <w>grahamedgecombe</w>
       <w>gxfx</w>
+      <w>hbckld</w>
       <w>hgvi</w>
       <w>hphtl</w>
+      <w>hqbaue</w>
       <w>htdm</w>
       <w>ihvc</w>
       <w>iuoo</w>
+      <w>iwjfe</w>
+      <w>jamk</w>
       <w>jgsf</w>
+      <w>jmct</w>
       <w>kbgh</w>
+      <w>kwkq</w>
+      <w>lkbi</w>
       <w>lqywbs</w>
+      <w>lzfv</w>
       <w>mbdim</w>
       <w>mhkqx</w>
       <w>miidvtcc</w>
       <w>mjcw</w>
+      <w>mjttjau</w>
       <w>mlwh</w>
+      <w>mnpw</w>
       <w>mxyf</w>
       <w>mzii</w>
       <w>nvbamt</w>
@@ -61,37 +83,53 @@
       <w>ohpm</w>
       <w>ohtb</w>
       <w>orczvmmz</w>
+      <w>pazo</w>
       <w>peewr</w>
       <w>ppsn</w>
       <w>psjo</w>
       <w>pubkey</w>
+      <w>pumm</w>
+      <w>pwzm</w>
       <w>qfahdg</w>
+      <w>qidaqab</w>
       <w>qwgg</w>
       <w>qwud</w>
       <w>qxauoh</w>
+      <w>raxi</w>
       <w>rboqknq</w>
       <w>rtimo</w>
       <w>sharedpref</w>
       <w>sjeg</w>
       <w>slgr</w>
       <w>slurper</w>
+      <w>spym</w>
       <w>sths</w>
       <w>szkrr</w>
       <w>tokener</w>
       <w>transparensbee</w>
+      <w>uegnh</w>
       <w>ulsrkn</w>
+      <w>urvzeuja</w>
       <w>veft</w>
+      <w>venafi</w>
       <w>vldt</w>
       <w>vpqy</w>
       <w>vrdvm</w>
       <w>vvfa</w>
       <w>vwmu</w>
+      <w>vxwdej</w>
+      <w>witkk</w>
+      <w>wtgn</w>
       <w>xhtol</w>
       <w>xiyykj</w>
       <w>xrrth</w>
       <w>yaht</w>
       <w>yfkbdf</w>
       <w>ymrly</w>
+      <w>yvxbc</w>
+      <w>zchw</w>
+      <w>zeiu</w>
+      <w>zhhdx</w>
       <w>zjzh</w>
     </words>
   </dictionary>

--- a/.idea/dictionaries/david.xml
+++ b/.idea/dictionaries/david.xml
@@ -8,6 +8,7 @@
       <w>baqufad</w>
       <w>bcjw</w>
       <w>bgkqhki</w>
+      <w>bqxi</w>
       <w>caqyi</w>
       <w>certspotter</w>
       <w>cftppk</w>
@@ -20,6 +21,7 @@
       <w>ctor</w>
       <w>ctserver</w>
       <w>culrj</w>
+      <w>dcuk</w>
       <w>difjpt</w>
       <w>dqebaquaa</w>
       <w>dzua</w>
@@ -82,8 +84,11 @@
       <w>vldt</w>
       <w>vpqy</w>
       <w>vrdvm</w>
+      <w>vvfa</w>
       <w>vwmu</w>
       <w>xhtol</w>
+      <w>xiyykj</w>
+      <w>xrrth</w>
       <w>yaht</w>
       <w>yfkbdf</w>
       <w>ymrly</w>

--- a/app/src/androidTest/java/party/davidsherenowitsa/transparensbee/VerifySTHTest.java
+++ b/app/src/androidTest/java/party/davidsherenowitsa/transparensbee/VerifySTHTest.java
@@ -1,0 +1,35 @@
+package party.davidsherenowitsa.transparensbee;
+
+import android.support.test.runner.AndroidJUnit4;
+import android.util.Base64;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public class VerifySTHTest {
+    @Test
+    public void testSignatureVerification() throws Exception {
+        LogServer pilot = new LogServer(
+                "ct.googleapis.com/pilot",
+                Base64.decode("MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEfahLEimAoz2t01p3uMziiLOl/fHTDM0YDOhBRuiBARsV4UvxG2LdNgoIGLrtCzWE0J5APC2em4JlvR8EEEFMoA==",
+                        Base64.DEFAULT),
+                "Google 'Pilot' log");
+        SignedTreeHead signedTreeHead = new SignedTreeHead(
+                1508457694549L,  // timestamp
+                160480356L,  // tree size
+                Base64.decode("TSPFlYW0wx+xrrthXS4w8OHXuEmP/e+86S0FQXaZC7o=", Base64.DEFAULT),  // root hash
+                Base64.decode("BAMARzBFAiAVsr7Dq8wBvj5ItmVXiyykjJn1zDs8DcukNVNW+cARgQIhAKF8Ns0VVFA26xuvZCTs7Na99uhzLCc0GfBIHo4rBQXI", Base64.DEFAULT));  // tree head signature
+        assertTrue(CryptoUtils.isSTHValid(signedTreeHead, pilot));
+
+        SignedTreeHead wrong = new SignedTreeHead(
+                signedTreeHead.getTimestamp() + 1,
+                signedTreeHead.getTreeSize(),
+                signedTreeHead.getRootHash(),
+                signedTreeHead.getTreeHeadSignature());
+        assertFalse(CryptoUtils.isSTHValid(wrong, pilot));
+    }
+}

--- a/app/src/androidTest/java/party/davidsherenowitsa/transparensbee/VerifySTHTest.java
+++ b/app/src/androidTest/java/party/davidsherenowitsa/transparensbee/VerifySTHTest.java
@@ -12,7 +12,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(AndroidJUnit4.class)
 public class VerifySTHTest {
     @Test
-    public void testSignatureVerification() throws Exception {
+    public void testECDSASignatureVerification() throws Exception {
         LogServer pilot = new LogServer(
                 "ct.googleapis.com/pilot",
                 Base64.decode("MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEfahLEimAoz2t01p3uMziiLOl/fHTDM0YDOhBRuiBARsV4UvxG2LdNgoIGLrtCzWE0J5APC2em4JlvR8EEEFMoA==",
@@ -31,5 +31,26 @@ public class VerifySTHTest {
                 signedTreeHead.getRootHash(),
                 signedTreeHead.getTreeHeadSignature());
         assertFalse(CryptoUtils.isSTHValid(wrong, pilot));
+    }
+
+    @Test
+    public void testRSASignatureVerification() throws Exception {
+        LogServer venafi = new LogServer(
+                "ctlog.api.venafi.com/",
+                Base64.decode("MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAolpIHxdSlTXLo1s6H1OCdpSj/4DyHDc8wLG9wVmLqy1lk9fz4ATVmm+/1iN2Nk8jmctUKK2MFUtlWXZBSpym97M7frGlSaQXUWyA3CqQUEuIJOmlEjKTBEiQAvpfDjCHjlV2Be4qTM6jamkJbiWtgnYPhJL6ONaGTiSPm7Byy57iaz/hbckldSOIoRhYBiMzeNoA0DiRZ9KmfSeXZ1rB8y8X5urSW+iBzf2SaOfzBvDpcoTuAaWx2DPazoOl28fP1hZ+kHUYvxbcMjttjauCFx+JII0dmuZNIwjfeG/GBb9frpSX219k1O4Wi6OEbHEr8at/XQ0y7gTikOxBn/s5wQIDAQAB", Base64.DEFAULT),
+                "Venafi log");
+        SignedTreeHead signedTreeHead = new SignedTreeHead(
+                1508592962212L,
+                99732L,
+                Base64.decode("qqHt4DkKFY6rb52tPQDaiLKBINaPm/UohEDenJ9vyz8=", Base64.DEFAULT),
+                Base64.decode("BAEBAHqbaueW2ZOEBeBLzfv9ZOyBezr92vxDCPwzm6hb1aGnBkgrrBlbUPummJ6uXUMCjJpWitkkWUXqDK+sueUNVruWyRxaBMmHXpXi9zeiuUKD33JKwkqWB+wAz9DhEI87kp1uizVPwCrDw3oyj/MnpwZchw1g7WMeEwQC8hXgsY6HB9sE2qtfMnyQcVxwdejO3tEuzzrBXPp3HkM3sM6UEGNH1Lt4urvzeujaRaxiAf3Glrrgmg6F0arD7ZhhdxB5GZa2+Rly6i41vsYJI/mK2gM19caczJVIsS01UQhHGjDMcpZvqRtLU10Cwqskwb11cFFXrX2YKvI6lVhaE9HWdYw=", Base64.DEFAULT));
+        assertTrue(CryptoUtils.isSTHValid(signedTreeHead, venafi));
+
+        SignedTreeHead wrong = new SignedTreeHead(
+                signedTreeHead.getTimestamp() + 1,
+                signedTreeHead.getTreeSize(),
+                signedTreeHead.getRootHash(),
+                signedTreeHead.getTreeHeadSignature());
+        assertFalse(CryptoUtils.isSTHValid(wrong, venafi));
     }
 }

--- a/app/src/main/java/party/davidsherenowitsa/transparensbee/PollinateJobIntentService.java
+++ b/app/src/main/java/party/davidsherenowitsa/transparensbee/PollinateJobIntentService.java
@@ -67,7 +67,13 @@ public class PollinateJobIntentService extends JobIntentService {
                     @Override
                     public Pair<LogServer, SignedTreeHead> call() throws Exception {
                         try {
-                            return new Pair<>(log, logClient.getSTHSynchronous(log));
+                            SignedTreeHead sth = logClient.getSTHSynchronous(log);
+                            if (CryptoUtils.isSTHValid(sth, log)) {
+                                return new Pair<>(log, sth);
+                            } else {
+                                statistics.addFailure(log);
+                                return null;
+                            }
                         } catch (SocketTimeoutException e) {
                             statistics.addFailure(log);
                             return null;

--- a/app/src/main/java/party/davidsherenowitsa/transparensbee/SignedTreeHead.java
+++ b/app/src/main/java/party/davidsherenowitsa/transparensbee/SignedTreeHead.java
@@ -3,8 +3,8 @@ package party.davidsherenowitsa.transparensbee;
 import java.util.Arrays;
 
 public class SignedTreeHead {
-    private final int version;
-    private final int signatureType;
+    private final byte version;
+    private final byte signatureType;
     private final long timestamp;
     private final long treeSize;
     private final byte[] rootHash;
@@ -20,12 +20,12 @@ public class SignedTreeHead {
         this.treeHeadSignature = treeHeadSignature;
     }
 
-    public int getVersion()
+    public byte getVersion()
     {
         return version;
     }
 
-    public int getSignatureType()
+    public byte getSignatureType()
     {
         return signatureType;
     }


### PR DESCRIPTION
This fixes #4. Signatures are verified on all STHs received from log servers. Nothing more is done with STHs received from pollination endpoints yet. If a log server provides a STH with an invalid signature, that will add one to the failure counter. (In the future, I'd like to store more detail than success/failure counters)